### PR TITLE
Added options to auto update SDK

### DIFF
--- a/.github/workflows/auto_sdk_update.yml
+++ b/.github/workflows/auto_sdk_update.yml
@@ -1,0 +1,42 @@
+name: Update Google Cloud SDK
+
+on:
+  schedule:
+    - cron: '0 4 * * 3' # At 04:00 on Wednesday
+  workflow_dispatch:    # or manually
+
+jobs:
+  update:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2.3.2
+      with:
+        ref: ${{ secrets.PAT }}  
+
+    - name: Get latest version of GCloud SDK
+      run: |
+        sudo apt update
+        sudo apt install snapd
+        sudo snap install google-cloud-sdk --classic
+        
+    - name: Set current and latest SDK version variables
+      run: |
+        echo "::set-env name=LATEST_GCLOUD_SDK::$(gcloud version | grep "Google Cloud SDK" |  sed 's/Google Cloud SDK //')"
+        echo "::set-env name=CURRENT_GCLOUD_SDK::$(cat google-cloud-sdk/VERSION)"
+        
+    - name: Update version
+      if: ${{ env.LATEST_GCLOUD_SDK != env.CURRENT_GCLOUD_SDK }}
+      run: |
+        ./update.sh $LATEST_GCLOUD_SDK
+    - name: Commit and push changes
+      uses: stefanzweifel/git-auto-commit-action@v4
+      if: ${{ env.LATEST_GCLOUD_SDK != env.CURRENT_GCLOUD_SDK }}
+      with:
+        commit_message: Update to ${{ env.LATEST_GCLOUD_SDK }}
+        branch: master
+        commit_options: '--no-verify --signoff'
+        file_pattern: .
+        skip_dirty_check: true

--- a/.github/workflows/auto_sdk_update.yml
+++ b/.github/workflows/auto_sdk_update.yml
@@ -13,8 +13,6 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v2.3.2
-      with:
-        ref: ${{ secrets.PAT }}  
 
     - name: Get latest version of GCloud SDK
       run: |

--- a/update.sh
+++ b/update.sh
@@ -9,7 +9,7 @@ set -euxo pipefail
 #
 # gsutil ls -l gs://cloud-sdk-release/for_packagers/linux > list.txt
 
-VERSION=303.0.0
+VERSION=$1
 SDK_TESTS=google-cloud-sdk-tests_$VERSION.orig.tar.gz
 SDK=google-cloud-sdk_$VERSION.orig.tar.gz
 
@@ -35,5 +35,3 @@ tar -xzf google-cloud-sdk-tests_$VERSION.orig.tar.gz
 rm google-cloud-sdk/bin/anthoscli
 
 gsutil ls -l gs://cloud-sdk-release/for_packagers/linux > list.txt
-
-git commit -am "Update to $VERSION"


### PR DESCRIPTION
Fixes #1 

Google Cloud SDK is mostly released on Tuesday, so created a scheduled job to auto-update SDK every Wednesday at 4:00 AM.

1. First script get the latest version of Google Cloud SDK
2. Then compare it with the current version
3. If versions do not match update it and push to master using Personal Access Token of Robo account